### PR TITLE
throw Error if AST is already instrumented

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,12 @@ API
 `espower` function manipulates `originalAst` then returns `modifiedAst` that is also an AST node object defined in [Mozilla JavaScript AST spec](https://developer.mozilla.org/en-US/docs/SpiderMonkey/Parser_API).
 If `destructive` option is falsy, `originalAst` will be unchanged. If `destructive` option is truthy, `originalAst` will be manipulated directly and returned `modifiedAst` will be the same instance of `originalAst`.
 
+`espower` function throws Error when
+
+* `originalAst` is already instrumented
+* `originalAst` does not contain location information
+* `options` argument is not valid
+
 
 #### originalAst
 

--- a/index.js
+++ b/index.js
@@ -16,13 +16,16 @@ var defaultOptions = require('./lib/default-options'),
 
 /**
  * Instrument power assert feature into code. Mozilla JS AST in, Mozilla JS AST out.
- * @param ast JavaScript Mozilla JS AST to instrument (directly modified if destructive option is truthy)
- * @param options Instrumentation options.
- * @return instrumented AST
+ * @param {object} originalAst JavaScript Mozilla JS AST to instrument (directly modified if destructive option is truthy)
+ * @param {object} options Instrumentation options.
+ * @returns {object} instrumented AST
+ * @throws {Error} if `originalAst` is already instrumented
+ * @throws {Error} if `originalAst` does not contain location information
+ * @throws {Error} if `options` is not valid
  */
-function espower (ast, options) {
+function espower (originalAst, options) {
     var instrumentor = new Instrumentor(extend(defaultOptions(), options));
-    return instrumentor.instrument(ast);
+    return instrumentor.instrument(originalAst);
 }
 
 espower.deepCopy = clone;

--- a/lib/assertion-visitor.js
+++ b/lib/assertion-visitor.js
@@ -4,6 +4,7 @@ var estraverse = require('estraverse'),
     escodegen = require('escodegen'),
     espurify = require('espurify'),
     clone = require('clone'),
+    deepEqual = require('deep-equal'),
     syntax = estraverse.Syntax,
     canonicalCodeOptions = {
         format: {
@@ -57,6 +58,23 @@ AssertionVisitor.prototype.enter = function (currentNode, parentNode) {
     }
 };
 
+AssertionVisitor.prototype.ensureNotInstrumented = function (currentNode) {
+    if (currentNode.type === syntax.CallExpression) {
+        if (currentNode.callee.type === syntax.MemberExpression) {
+            var prop = currentNode.callee.property;
+            if (prop.type === syntax.Identifier && prop.name === '_expr') {
+                if (deepEqual(espurify(currentNode.callee.object), espurify(this.powerAssertCallee))) {
+                    var errorMessage = 'Attempted to transform AST twice.';
+                    if (this.options.path) {
+                        errorMessage += ' path: ' + this.options.path;
+                    }
+                    throw new Error(errorMessage);
+                }
+            }
+        }
+    }
+};
+
 AssertionVisitor.prototype.enterArgument = function (currentNode, parentNode, path) {
     var argMatchResult = this.matcher.matchArgument(currentNode, parentNode);
     if (argMatchResult) {
@@ -64,6 +82,7 @@ AssertionVisitor.prototype.enterArgument = function (currentNode, parentNode, pa
             // skip optional message argument
             return undefined;
         }
+        this.ensureNotInstrumented(currentNode);
         // entering target argument
         this.currentArgumentPath = [].concat(path);
         return undefined;

--- a/lib/assertion-visitor.js
+++ b/lib/assertion-visitor.js
@@ -16,6 +16,10 @@ var estraverse = require('estraverse'),
         verbatim: 'x-verbatim-espower'
     };
 
+function astEqual (ast1, ast2) {
+    return deepEqual(espurify(ast1), espurify(ast2));
+}
+
 // see: https://github.com/Constellation/escodegen/issues/115
 if (typeof define === 'function' && define.amd) {
     escodegen = window.escodegen;
@@ -59,18 +63,20 @@ AssertionVisitor.prototype.enter = function (currentNode, parentNode) {
 };
 
 AssertionVisitor.prototype.ensureNotInstrumented = function (currentNode) {
-    if (currentNode.type === syntax.CallExpression) {
-        if (currentNode.callee.type === syntax.MemberExpression) {
-            var prop = currentNode.callee.property;
-            if (prop.type === syntax.Identifier && prop.name === '_expr') {
-                if (deepEqual(espurify(currentNode.callee.object), espurify(this.powerAssertCallee))) {
-                    var errorMessage = 'Attempted to transform AST twice.';
-                    if (this.options.path) {
-                        errorMessage += ' path: ' + this.options.path;
-                    }
-                    throw new Error(errorMessage);
-                }
+    if (currentNode.type !== syntax.CallExpression) {
+        return;
+    }
+    if (currentNode.callee.type !== syntax.MemberExpression) {
+        return;
+    }
+    var prop = currentNode.callee.property;
+    if (prop.type === syntax.Identifier && prop.name === '_expr') {
+        if (astEqual(currentNode.callee.object, this.powerAssertCallee)) {
+            var errorMessage = 'Attempted to transform AST twice.';
+            if (this.options.path) {
+                errorMessage += ' path: ' + this.options.path;
             }
+            throw new Error(errorMessage);
         }
     }
 };

--- a/lib/assertion-visitor.js
+++ b/lib/assertion-visitor.js
@@ -36,7 +36,7 @@ function AssertionVisitor (matcher, path, sourceMapConsumer, options) {
 
 AssertionVisitor.prototype.enter = function (currentNode, parentNode) {
     this.canonicalCode = generateCanonicalCode(currentNode);
-    this.powerAssertCallee = guessPowerAssertCalleeFor(currentNode.callee);
+    this.powerAssertCalleeObject = guessPowerAssertCalleeObjectFor(currentNode.callee);
 
     if (this.sourceMapConsumer) {
         var pos = this.sourceMapConsumer.originalPositionFor({
@@ -71,7 +71,7 @@ AssertionVisitor.prototype.ensureNotInstrumented = function (currentNode) {
     }
     var prop = currentNode.callee.property;
     if (prop.type === syntax.Identifier && prop.name === '_expr') {
-        if (astEqual(currentNode.callee.object, this.powerAssertCallee)) {
+        if (astEqual(currentNode.callee.object, this.powerAssertCalleeObject)) {
             var errorMessage = 'Attempted to transform AST twice.';
             if (this.options.path) {
                 errorMessage += ' path: ' + this.options.path;
@@ -121,7 +121,7 @@ AssertionVisitor.prototype.isLeavingArgument = function (nodePath) {
 AssertionVisitor.prototype.captureArgument = function (node) {
     var n = newNodeWithLocationCopyOf(node),
         props = [],
-        newCallee = updateLocRecursively(espurify(this.powerAssertCallee), n);
+        newCalleeObject = updateLocRecursively(espurify(this.powerAssertCalleeObject), n);
     addLiteralTo(props, n, 'content', this.canonicalCode);
     addLiteralTo(props, n, 'filepath', this.filepath);
     addLiteralTo(props, n, 'line', this.lineNum);
@@ -130,7 +130,7 @@ AssertionVisitor.prototype.captureArgument = function (node) {
         callee: n({
             type: syntax.MemberExpression,
             computed: false,
-            object: newCallee,
+            object: newCalleeObject,
             property: n({
                 type: syntax.Identifier,
                 name: '_expr'
@@ -147,13 +147,13 @@ AssertionVisitor.prototype.captureNode = function (target, path) {
     this.argumentModified = true;
     var n = newNodeWithLocationCopyOf(target),
         relativeEsPath = path.slice(this.assertionPath.length),
-        newCallee = updateLocRecursively(espurify(this.powerAssertCallee), n);
+        newCalleeObject = updateLocRecursively(espurify(this.powerAssertCalleeObject), n);
     return n({
         type: syntax.CallExpression,
         callee: n({
             type: syntax.MemberExpression,
             computed: false,
-            object: newCallee,
+            object: newCalleeObject,
             property: n({
                 type: syntax.Identifier,
                 name: '_capt'
@@ -169,7 +169,7 @@ AssertionVisitor.prototype.captureNode = function (target, path) {
     });
 };
 
-function guessPowerAssertCalleeFor (node) {
+function guessPowerAssertCalleeObjectFor (node) {
     switch(node.type) {
     case syntax.Identifier:
         return node;

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "clone": "~0.2.0",
+    "deep-equal": "~1.0.0",
     "escallmatch": "~1.0.1",
     "escodegen": "~1.4.1",
     "espurify": "~1.0.0",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "clone": "~0.2.0",
     "deep-equal": "~1.0.0",
-    "escallmatch": "~1.0.1",
+    "escallmatch": "~1.1.0",
     "escodegen": "~1.4.1",
     "espurify": "~1.0.0",
     "estraverse": "~1.9.1",

--- a/test/espower_option_test.js
+++ b/test/espower_option_test.js
@@ -182,6 +182,19 @@ describe('AST prerequisites. Error should be thrown if location is missing.', fu
 });
 
 
+it('AST prerequisites. Error should be thrown if AST is already instrumented.', function () {
+    var alreadyEspoweredCode = "assert(assert._expr(assert._capt(falsyStr,'arguments/0'),{content:'assert(falsyStr)',filepath:'/path/to/some_test.js',line:1}));";
+    var ast = esprima.parse(alreadyEspoweredCode, {tolerant: true, loc: true, raw: true});
+    try {
+        espower(ast, {destructive: false, source: alreadyEspoweredCode, path: '/path/to/baz_test.js'});
+        assert.ok(false, 'Error should be thrown');
+    } catch (e) {
+        assert.equal(e.name, 'Error');
+        assert.equal(e.message, 'Attempted to transform AST twice. path: /path/to/baz_test.js');
+    }
+});
+
+
 describe('location information', function () {
     it('preserve location of instrumented nodes.', function () {
         var jsCode = 'assert((three * (seven * ten)) === three);',

--- a/test/espower_option_test.js
+++ b/test/espower_option_test.js
@@ -182,16 +182,39 @@ describe('AST prerequisites. Error should be thrown if location is missing.', fu
 });
 
 
-it('AST prerequisites. Error should be thrown if AST is already instrumented.', function () {
-    var alreadyEspoweredCode = "assert(assert._expr(assert._capt(falsyStr,'arguments/0'),{content:'assert(falsyStr)',filepath:'/path/to/some_test.js',line:1}));";
-    var ast = esprima.parse(alreadyEspoweredCode, {tolerant: true, loc: true, raw: true});
-    try {
-        espower(ast, {destructive: false, source: alreadyEspoweredCode, path: '/path/to/baz_test.js'});
-        assert.ok(false, 'Error should be thrown');
-    } catch (e) {
-        assert.equal(e.name, 'Error');
-        assert.equal(e.message, 'Attempted to transform AST twice. path: /path/to/baz_test.js');
-    }
+describe('AST prerequisites. Error should be thrown if AST is already instrumented.', function () {
+
+    it('when going to instrument "assert(falsyStr);" twice', function () {
+        var alreadyEspoweredCode = "assert(assert._expr(assert._capt(falsyStr,'arguments/0'),{content:'assert(falsyStr)',filepath:'/path/to/some_test.js',line:1}));";
+        var ast = esprima.parse(alreadyEspoweredCode, {tolerant: true, loc: true, raw: true});
+        try {
+            espower(ast, {destructive: false, source: alreadyEspoweredCode, path: '/path/to/baz_test.js'});
+            assert.ok(false, 'Error should be thrown');
+        } catch (e) {
+            assert.equal(e.name, 'Error');
+            assert.equal(e.message, 'Attempted to transform AST twice. path: /path/to/baz_test.js');
+        }
+    });
+
+    it('when going to instrument "browser.assert.element(foo);" twice', function () {
+        var alreadyEspoweredCode = "browser.assert.element(browser.assert._expr(browser.assert._capt(foo,'arguments/0'),{content:'browser.assert.element(foo)',line:1}));";
+        var ast = esprima.parse(alreadyEspoweredCode, {tolerant: true, loc: true, raw: true});
+        try {
+            espower(ast, {
+                destructive: false,
+                source: alreadyEspoweredCode,
+                path: '/path/to/foo_test.js',
+                patterns: [
+                    'browser.assert.element(selection, [message])'
+                ]
+            });
+            assert.ok(false, 'Error should be thrown');
+        } catch (e) {
+            assert.equal(e.name, 'Error');
+            assert.equal(e.message, 'Attempted to transform AST twice. path: /path/to/foo_test.js');
+        }
+    });
+
 });
 
 


### PR DESCRIPTION
`espower` function transforms AST even if it is already transformed.
([reported by @stomita](https://gist.github.com/stomita/df4a4826eb9278e3d853))

This is not a desirable behavior in most cases.

Throwing error would be an appropriate solution since callers of `espower` (for example, `espower-source` module) know original JS code and SourceMap so they can abort / skip / rollback transformation process.

### TODO
- [x] add bug reproduction case when AST is instrumented twice
- [x] throw Error if AST is already instrumented
- [x] refactor
- [x] update document
- [x] provide option for strict or loose behavior ? -> not now