### PR TITLE
sourceRoot option

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,15 @@ Detection is done by [escallmatch](http://github.com/twada/escallmatch). Any arg
 Filepath of `originalAst`. If passed, espower stores filepath information for reporting. This property is optional.
 
 
+#### (optional) options.sourceRoot
+
+| type     | default value |
+|:---------|:--------------|
+| `string` | N/A           |
+
+Root filepath for target test files. Only works with `options.path` or `options.sourceMap`. If set, filepath in power-assert output will be relative from `options.sourceRoot`. This property is optional.
+
+
 #### (optional) options.sourceMap
 
 | type                | default value |

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Filepath of `originalAst`. If passed, espower stores filepath information for re
 |:---------|:--------------|
 | `string` | N/A           |
 
-Root filepath for target test files. Only works with `options.path` or `options.sourceMap`. If set, filepath in power-assert output will be relative from `options.sourceRoot`. This property is optional.
+Root filepath for target test files. Only works with `options.path` or `options.sourceMap`. If set, filepath in power-assert output will be relative from `options.sourceRoot`. When both `options.sourceRoot` and sourceMap's sourceRoot are given, `options.sourceRoot` has precedence over sourceMap's sourceRoot. This property is optional.
 
 
 #### (optional) options.sourceMap

--- a/lib/assertion-visitor.js
+++ b/lib/assertion-visitor.js
@@ -62,7 +62,14 @@ AssertionVisitor.prototype.enter = function (currentNode, parentNode) {
     }
 
     if (!this.filepath) {
-        this.filepath = this.options.path;
+        if (this.options.sourceRoot) {
+            var sourceRoot = this.options.sourceRoot;
+            var endsWithSlash = sourceRoot.lastIndexOf('/') === (sourceRoot.length - 1);
+            var sep = endsWithSlash ? '' : '/';
+            this.filepath = this.options.path.replace(sourceRoot + sep, '');
+        } else {
+            this.filepath = this.options.path;
+        }
     }
     if (!this.lineNum) {
         this.lineNum = currentNode.loc.start.line;

--- a/lib/assertion-visitor.js
+++ b/lib/assertion-visitor.js
@@ -56,6 +56,8 @@ AssertionVisitor.prototype.enter = function (currentNode, parentNode) {
             if (pos.source) {
                 if (this.sourceMapConsumer.sourceRoot) {
                     this.filepath = _path.relative(this.sourceMapConsumer.sourceRoot, pos.source);
+                } else if (this.options.sourceRoot) {
+                    this.filepath = _path.relative(this.options.sourceRoot, pos.source);
                 } else {
                     this.filepath = pos.source;
                 }

--- a/lib/assertion-visitor.js
+++ b/lib/assertion-visitor.js
@@ -20,6 +20,7 @@ var canonicalCodeOptions = {
     },
     verbatim: 'x-verbatim-espower'
 };
+var _path = require('path');
 
 function astEqual (ast1, ast2) {
     return deepEqual(espurify(ast1), espurify(ast2));
@@ -53,7 +54,11 @@ AssertionVisitor.prototype.enter = function (currentNode, parentNode) {
         if (pos) {
             // console.log(JSON.stringify(pos, null, 2));
             if (pos.source) {
-                this.filepath = pos.source;
+                if (this.sourceMapConsumer.sourceRoot) {
+                    this.filepath = _path.relative(this.sourceMapConsumer.sourceRoot, pos.source);
+                } else {
+                    this.filepath = pos.source;
+                }
             }
             if (pos.line) {
                 this.lineNum = pos.line;
@@ -63,10 +68,7 @@ AssertionVisitor.prototype.enter = function (currentNode, parentNode) {
 
     if (!this.filepath) {
         if (this.options.sourceRoot) {
-            var sourceRoot = this.options.sourceRoot;
-            var endsWithSlash = sourceRoot.lastIndexOf('/') === (sourceRoot.length - 1);
-            var sep = endsWithSlash ? '' : '/';
-            this.filepath = this.options.path.replace(sourceRoot + sep, '');
+            this.filepath = _path.relative(this.options.sourceRoot, this.options.path);
         } else {
             this.filepath = this.options.path;
         }

--- a/lib/assertion-visitor.js
+++ b/lib/assertion-visitor.js
@@ -54,10 +54,10 @@ AssertionVisitor.prototype.enter = function (currentNode, parentNode) {
         if (pos) {
             // console.log(JSON.stringify(pos, null, 2));
             if (pos.source) {
-                if (this.sourceMapConsumer.sourceRoot) {
-                    this.filepath = _path.relative(this.sourceMapConsumer.sourceRoot, pos.source);
-                } else if (this.options.sourceRoot) {
+                if (this.options.sourceRoot) {
                     this.filepath = _path.relative(this.options.sourceRoot, pos.source);
+                } else if (this.sourceMapConsumer.sourceRoot) {
+                    this.filepath = _path.relative(this.sourceMapConsumer.sourceRoot, pos.source);
                 } else {
                     this.filepath = pos.source;
                 }

--- a/test/espower_option_test.js
+++ b/test/espower_option_test.js
@@ -374,6 +374,35 @@ describe('SourceMap support', function () {
 
         assert.equal(espoweredCode, "var str='foo';var anotherStr='bar';assert.equal(assert._expr(assert._capt(str,'arguments/0'),{content:'assert.equal(str, anotherStr)',filepath:'test/original_test.js',line:4}),assert._expr(assert._capt(anotherStr,'arguments/1'),{content:'assert.equal(str, anotherStr)',filepath:'test/original_test.js',line:4}));");
     });
+
+
+    it('when options.sourceRoot is given and sourceMap.sourceRoot is not given', function () {
+        var originalPath = '/path/to/project/test/original_test.js';
+        var originalCode = 'var str = "foo";\nvar anotherStr = "bar"\n\nassert.equal(\nstr,\nanotherStr\n);';
+
+        var compactResult = escodegen.generate(acorn.parse(originalCode, {ecmaVersion: 6, locations: true, sourceFile: originalPath}), {
+            format: {
+                compact: true
+            },
+            sourceMap: true,
+            sourceMapWithCode: true
+        });
+
+        var compactCode = compactResult.code;
+        var sourceMap = compactResult.map.toString();
+
+        var espoweredAST = espower(acorn.parse(compactCode, {ecmaVersion: 6, locations: true, sourceFile: originalPath}), {
+            patterns: [
+                'assert.equal(actual, expected, [message])'
+            ],
+            sourceMap: sourceMap,
+            sourceRoot: '/path/to/project/'
+        });
+
+        var espoweredCode = escodegen.generate(espoweredAST, {format: {compact: true}});
+
+        assert.equal(espoweredCode, "var str='foo';var anotherStr='bar';assert.equal(assert._expr(assert._capt(str,'arguments/0'),{content:'assert.equal(str, anotherStr)',filepath:'test/original_test.js',line:4}),assert._expr(assert._capt(anotherStr,'arguments/1'),{content:'assert.equal(str, anotherStr)',filepath:'test/original_test.js',line:4}));");
+    });
 });
 
 

--- a/test/espower_option_test.js
+++ b/test/espower_option_test.js
@@ -377,4 +377,30 @@ describe('SourceMap support', function () {
 });
 
 
+describe('sourceRoot option', function () {
+    function instrumentCodeWithOptions (espowerOptions) {
+        var jsCode = 'assert(falsyStr);';
+        var jsAST = acorn.parse(jsCode, {ecmaVersion: 6, locations: true, sourceFile: '/path/to/project/test/some_test.js'});
+        var espoweredAST = espower(jsAST, espowerOptions);
+        return escodegen.generate(espoweredAST, {format: {compact: true}});
+    }
+
+    it('when sourceRoot ends with slash', function () {
+        var instrumentedCode = instrumentCodeWithOptions({
+            path: '/path/to/project/test/some_test.js',
+            sourceRoot: '/path/to/project/'
+        });
+        assert.equal(instrumentedCode, "assert(assert._expr(assert._capt(falsyStr,'arguments/0'),{content:'assert(falsyStr)',filepath:'test/some_test.js',line:1}));");
+    });
+
+    it('when sourceRoot does not end with slash', function () {
+        var instrumentedCode = instrumentCodeWithOptions({
+            path: '/path/to/project/test/some_test.js',
+            sourceRoot: '/path/to/project'
+        });
+        assert.equal(instrumentedCode, "assert(assert._expr(assert._capt(falsyStr,'arguments/0'),{content:'assert(falsyStr)',filepath:'test/some_test.js',line:1}));");
+    });
+});
+
+
 }));

--- a/test/espower_option_test.js
+++ b/test/espower_option_test.js
@@ -343,13 +343,13 @@ describe('SourceMap support', function () {
     });
 
 
-    it('when escodegen sourceMapRoot is given', function () {
-        var originalBasePath = '/path/to/base/';
-        var originalRelativePath = 'original_test.js';
+    it('when sourceRoot in SourceMap is given', function () {
+        var originalBasePath = '/path/to/base';
+        var originalRelativePath = 'test/original_test.js';
         var originalCode = 'var str = "foo";\nvar anotherStr = "bar"\n\nassert.equal(\nstr,\nanotherStr\n);';
         // console.log(originalCode);
 
-        var compactResult = escodegen.generate(acorn.parse(originalCode, {ecmaVersion: 6, locations: true, sourceFile: originalBasePath + originalRelativePath}), {
+        var compactResult = escodegen.generate(acorn.parse(originalCode, {ecmaVersion: 6, locations: true, sourceFile: originalRelativePath}), {
             format: {
                 compact: true
             },
@@ -363,7 +363,7 @@ describe('SourceMap support', function () {
         var sourceMap = compactResult.map.toString();
         // console.log(sourceMap);
 
-        var espoweredAST = espower(acorn.parse(compactCode, {ecmaVersion: 6, locations: true, sourceFile: originalBasePath + originalRelativePath}), {
+        var espoweredAST = espower(acorn.parse(compactCode, {ecmaVersion: 6, locations: true, sourceFile: originalRelativePath}), {
             patterns: [
                 'assert.equal(actual, expected, [message])'
             ],
@@ -372,7 +372,7 @@ describe('SourceMap support', function () {
 
         var espoweredCode = escodegen.generate(espoweredAST, {format: {compact: true}});
 
-        assert.equal(espoweredCode, "var str='foo';var anotherStr='bar';assert.equal(assert._expr(assert._capt(str,'arguments/0'),{content:'assert.equal(str, anotherStr)',filepath:'/path/to/base/original_test.js',line:4}),assert._expr(assert._capt(anotherStr,'arguments/1'),{content:'assert.equal(str, anotherStr)',filepath:'/path/to/base/original_test.js',line:4}));");
+        assert.equal(espoweredCode, "var str='foo';var anotherStr='bar';assert.equal(assert._expr(assert._capt(str,'arguments/0'),{content:'assert.equal(str, anotherStr)',filepath:'test/original_test.js',line:4}),assert._expr(assert._capt(anotherStr,'arguments/1'),{content:'assert.equal(str, anotherStr)',filepath:'test/original_test.js',line:4}));");
     });
 });
 

--- a/test/espower_option_test.js
+++ b/test/espower_option_test.js
@@ -403,6 +403,38 @@ describe('SourceMap support', function () {
 
         assert.equal(espoweredCode, "var str='foo';var anotherStr='bar';assert.equal(assert._expr(assert._capt(str,'arguments/0'),{content:'assert.equal(str, anotherStr)',filepath:'test/original_test.js',line:4}),assert._expr(assert._capt(anotherStr,'arguments/1'),{content:'assert.equal(str, anotherStr)',filepath:'test/original_test.js',line:4}));");
     });
+
+
+    it('when both options.sourceRoot and sourceMap.sourceRoot are given, options.sourceRoot has precedence over sourceMap.sourceRoot', function () {
+        var originalBasePath = '/path/to';
+        var originalRelativePath = 'project/test/original_test.js';
+        var originalCode = 'var str = "foo";\nvar anotherStr = "bar"\n\nassert.equal(\nstr,\nanotherStr\n);';
+
+        var compactResult = escodegen.generate(acorn.parse(originalCode, {ecmaVersion: 6, locations: true, sourceFile: originalRelativePath}), {
+            format: {
+                compact: true
+            },
+            sourceMap: true,
+            sourceMapRoot: originalBasePath,
+            sourceMapWithCode: true
+        });
+
+        var compactCode = compactResult.code;
+        var sourceMap = compactResult.map.toString();
+
+        var espoweredAST = espower(acorn.parse(compactCode, {ecmaVersion: 6, locations: true, sourceFile: originalRelativePath}), {
+            patterns: [
+                'assert.equal(actual, expected, [message])'
+            ],
+            sourceMap: sourceMap,
+            sourceRoot: '/path/to/project/'
+        });
+
+        var espoweredCode = escodegen.generate(espoweredAST, {format: {compact: true}});
+
+        assert.equal(espoweredCode, "var str='foo';var anotherStr='bar';assert.equal(assert._expr(assert._capt(str,'arguments/0'),{content:'assert.equal(str, anotherStr)',filepath:'test/original_test.js',line:4}),assert._expr(assert._capt(anotherStr,'arguments/1'),{content:'assert.equal(str, anotherStr)',filepath:'test/original_test.js',line:4}));");
+    });
+
 });
 
 


### PR DESCRIPTION
Introduce `sourceRoot` option.

- `options.sourceRoot` is a root filepath for target test files.
- It only works with `options.path` or `options.sourceMap`.
- If set, filepath in power-assert output will be relative from `options.sourceRoot`.
- When both `options.sourceRoot` and sourceMap's sourceRoot are given, `options.sourceRoot` has precedence over sourceMap's sourceRoot.

#### TODO

- [x] document
- [x] test
- [x] implement
- [x] refactor
